### PR TITLE
Missing red node

### DIFF
--- a/red-scare/doc/red-scare.tex
+++ b/red-scare/doc/red-scare.tex
@@ -636,7 +636,7 @@ There is an edge from  $\alpha_i$ to $\alpha_j$ if $i<j$ and $\alpha_i<\alpha_j$
 \begin{figure}
  \begin{tikzpicture}[]
  \begin{scope}[every node/.style={circle, fill, inner sep =1.5pt}]
-   \node (11)  [label=below:$11$, label = left:$s$] at (0,0) {};
+   \node (11)  [label=below:$11$, fill=red, label = left:$s$] at (0,0) {};
    \node (15) [label=below:$15$, fill=red, draw] at (1,0) {};
    \node (1)  [label=below:$1$,  fill=red, draw] at (2,0) {};
    \node (8) [label=below:$8$] at (3,0) {};


### PR DESCRIPTION
It's missing a red node in the TiKZ visualization of increase-n8-2.0.txt (last figure)